### PR TITLE
Add navigation bar and align hero with brand colors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,17 @@
-import Hero from './components/Hero'
-import AboutUs from './components/AboutUs'
-import InvestmentStrategy from './components/InvestmentStrategy'
-import InvestmentSectors from './components/InvestmentSectors'
-import TrustResults from './components/TrustResults'
-import ContactForm from './components/ContactForm'
-import Footer from './components/Footer'
-import './App.css'
+import Navbar from './components/Navbar';
+import Hero from './components/Hero';
+import AboutUs from './components/AboutUs';
+import InvestmentStrategy from './components/InvestmentStrategy';
+import InvestmentSectors from './components/InvestmentSectors';
+import TrustResults from './components/TrustResults';
+import ContactForm from './components/ContactForm';
+import Footer from './components/Footer';
+import './App.css';
 
 function App() {
   return (
     <>
+      <Navbar />
       <Hero />
       <AboutUs />
       <InvestmentStrategy />
@@ -18,7 +20,7 @@ function App() {
       <ContactForm />
       <Footer />
     </>
-  )
+  );
 }
 
 export default App;

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -9,7 +9,7 @@ const Hero = () => {
   return (
     <section className="hero">
       <div className="hero-content">
-        <h1>Invertimos con inteligencia, crecemos con vision.</h1>
+        <h1>Invertimos con inteligencia, crecemos con visión.</h1>
         <p className="subtitle">Fondo privado de inversión con visión global y estrategias diversificadas.</p>
         <button className="cta-button" onClick={scrollToStrategy}>
           Conoce nuestras estrategias

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import '../styles/Navbar.css';
+
+const Navbar = () => {
+  const navItems = [
+    { label: 'Inicio', href: '#' },
+    { label: 'Nosotros', href: '#about' },
+    { label: 'Estrategia', href: '#strategy' },
+    { label: 'Sectores', href: '#sectors' },
+    { label: 'Resultados', href: '#results' },
+    { label: 'Contacto', href: '#contact' }
+  ];
+
+  return (
+    <header className="navbar">
+      <div className="navbar-container">
+        <a href="#" className="navbar-brand">PANDA HOLDING</a>
+        <nav className="navbar-nav">
+          {navItems.map((item) => (
+            <a key={item.href} href={item.href} className="nav-link">
+              {item.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+html {
+  scroll-behavior: smooth;
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/src/styles/Hero.css
+++ b/src/styles/Hero.css
@@ -8,6 +8,7 @@
   text-align: center;
   color: var(--white);
   overflow: hidden;
+  padding: 0 1rem;
 }
 
 .hero-background {
@@ -16,7 +17,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(90deg, #2c3040, #414042, #161414, #151312);
+  background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
   z-index: -1;
 }
 
@@ -41,7 +42,7 @@
 }
 
 .cta-button {
-  background-color: #edb039;
+  background-color: var(--accent-color);
   color: var(--primary-color);
   padding: 1rem 2rem;
   border: none;
@@ -49,10 +50,12 @@
   font-size: 1.1rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.3s ease, color 0.3s ease;
 }
 
 .cta-button:hover {
+  background-color: var(--secondary-color);
+  color: var(--white);
   transform: translateY(-2px);
 }
 

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -1,0 +1,46 @@
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: var(--white);
+  border-bottom: 1px solid var(--light-gray);
+  z-index: 1000;
+}
+
+.navbar-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+}
+
+.navbar-brand {
+  font-weight: 700;
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.navbar-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-link {
+  color: var(--primary-color);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.3s ease;
+}
+
+.nav-link:hover {
+  color: var(--secondary-color);
+}
+
+@media (max-width: 768px) {
+  .navbar-nav {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add fixed navigation bar for quick access to all sections
- restyle hero with brand color gradient and accented call-to-action
- enable smooth scrolling between sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e5a03961883278695fed163c91c77