### PR TITLE
feat: apply custom fonts and color scheme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,103 +1,18 @@
 #root {
   width: 100%;
 }
-:root {
-  /* Colors */
-  --color-copper-black: #161412; /* Copper Black */
-  --color-deep-copper: #835811;  /* Deep Copper */
-  --color-royal-copper: #ae720a; /* Royal Copper */
-  --color-mid-copper: #edb039;   /* Mid Copper */
 
-  /* 'Copperish Gold' figura como degradado sin paradas exactas en el doc.
-     Propongo este gradiente basado en la paleta: */
-  --gradient-copperish-gold: linear-gradient(135deg, #ae720a 0%, #edb039 50%, #835811 100%);
-
-  /* Typography (familias primarias del documento) */
-  --font-baba-pro: "Baba Pro", sans-serif;
-  --font-adam: "ADAM", "Adam", sans-serif;
-  --font-nexa: "Nexa", "Nexa Regular", sans-serif;
-
-  /* Alias para uso rápido */
-  --font-base: var(--font-nexa);
-  --font-heading: var(--font-baba-pro);
-  --font-accent: var(--font-adam);
-
-  /* Pesos sugeridos (ajusta según los archivos que instales) */
-  --weight-regular: 400;
-  --weight-medium: 500;
-  --weight-bold: 700;
-}
-
-
-
-/* FONTS */
-@font-face {
-  font-family: 'BabaPro';
-  src: url('../fonts/Babapro.otf') format('opentype');
-}
-
-@font-face {
-  font-family: 'BabaPro-Bold';
-  src: url('../fonts/Babapro-Bold.otf') format('opentype');
-}
-
-@font-face {
-  font-family: 'Adam-Light';
-  src: url('../fonts/Adam-Light.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'Adam-Bold';
-  src: url('../fonts/Adam-Bold.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'Adam-Medium';
-  src: url('../fonts/Adam-Medium.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'Nexa-ExtraLight';
-  src: url('../fonts/Nexa-ExtraLight.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'Nexa-Heavy';
-  src: url('../fonts/Nexa-Heavy.ttf') format('truetype');
-}
-
-
-/* pruebas de fuentes */
-
-.babapro {
-  font-family: 'BabaPro';
-}
-.babaproBold {
-  font-family: 'BabaPro-Bold';
-}
-.adamLight {
-  font-family: 'Adam-Light';
-}
-.adamBold {
-  font-family: 'Adam-Bold';
-}
-.adamMedium {
-  font-family: 'Adam-Medium';
-}
-.nexaExtra {
-  font-family: 'Nexa-ExtraLight';
-}
-.nexaHeavy {
-  font-family: 'Nexa-Heavy';
-}
-
+/* Global typography */
 body {
-  font-family: 'Nexa-ExtraLight';
+  font-family: var(--font-base);
 }
 
 h1 {
-  font-family: 'BabaPro-Bold';
+  font-family: var(--font-heading);
+  font-weight: 700;
 }
+
 h2, h3, h4, h5, h6 {
-  font-family: 'Adam-Bold';
+  font-family: var(--font-subheading);
+  font-weight: 700;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,52 @@
+@font-face {
+  font-family: 'BabaPro';
+  src: url('../fonts/Babapro.otf') format('opentype');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'BabaPro';
+  src: url('../fonts/Babapro-Bold.otf') format('opentype');
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Adam';
+  src: url('../fonts/Adam-Light.ttf') format('truetype');
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Adam';
+  src: url('../fonts/Adam-Medium.ttf') format('truetype');
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Adam';
+  src: url('../fonts/Adam-Bold.ttf') format('truetype');
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Nexa';
+  src: url('../fonts/Nexa-ExtraLight.ttf') format('truetype');
+  font-weight: 200;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Nexa';
+  src: url('../fonts/Nexa-Heavy.ttf') format('truetype');
+  font-weight: 800;
+  font-style: normal;
+}
+
 html {
   scroll-behavior: smooth;
 }
@@ -16,7 +65,11 @@ html {
   --light-gray: #f5f5f5;
   --white: #ffffff;
 
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  --font-base: 'Nexa', sans-serif;
+  --font-heading: 'BabaPro', sans-serif;
+  --font-subheading: 'Adam', sans-serif;
+
+  font-family: var(--font-base);
   line-height: 1.5;
   font-weight: 400;
 

--- a/src/styles/Hero.css
+++ b/src/styles/Hero.css
@@ -32,13 +32,14 @@
   font-weight: 700;
   margin-bottom: 1.5rem;
   line-height: 1.2;
-  font-family: 'BabaPro-Bold';
+  font-family: var(--font-heading);
 }
 
 .hero .subtitle {
   font-size: 1.5rem;
   margin-bottom: 2rem;
   opacity: 0.9;
+  font-family: var(--font-subheading);
 }
 
 .cta-button {
@@ -49,6 +50,7 @@
   border-radius: 5px;
   font-size: 1.1rem;
   font-weight: 600;
+  font-family: var(--font-base);
   cursor: pointer;
   transition: background-color 0.3s ease, transform 0.3s ease, color 0.3s ease;
 }

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -18,9 +18,15 @@
 }
 
 .navbar-brand {
+  font-family: var(--font-heading);
   font-weight: 700;
-  color: var(--primary-color);
+  color: var(--accent-color);
   text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.navbar-brand:hover {
+  color: var(--secondary-color);
 }
 
 .navbar-nav {
@@ -29,6 +35,7 @@
 }
 
 .nav-link {
+  font-family: var(--font-subheading);
   color: var(--primary-color);
   text-decoration: none;
   font-weight: 500;


### PR DESCRIPTION
## Summary
- load Nexa, BabaPro and Adam fonts globally
- use README color palette with updated navbar and hero styling

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e5e52b88c8327b85f2da5362c99fb